### PR TITLE
[codex] remove Vercel cron scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable platform-level changes for this repository are documented here.
 - Fixed Next.js i18n locale matcher import issues
 - Stabilized production deployment workflows
 - Corrected health endpoint configurations for both platforms
+- Removed the Vercel cron scheduler so scheduled work stays on the Strapi/EasyPanel side
 
 ### Deployment
 

--- a/vercel.json
+++ b/vercel.json
@@ -12,12 +12,6 @@
     }
   },
   "regions": ["iad1", "sfo1"],
-  "crons": [
-    {
-      "path": "/api/health",
-      "schedule": "0 */6 * * *"
-    }
-  ],
   "headers": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## What changed
- Removes the Vercel cron scheduler from `vercel.json`.
- Keeps the `/api/health` route for normal health checks, but stops Vercel from owning scheduled execution.
- Adds a changelog note to document that scheduled work now belongs on the Strapi/EasyPanel side.

## Why
- Vercel Hobby cron limits caused the deployment status check to fail.
- Strapi already owns the backend workflow, so scheduling belongs on the Strapi/EasyPanel side instead of duplicating it on Vercel.

## Validation
- Confirmed the only cron reference was removed from `vercel.json`.
- Ran `git diff --check` before commit.
- Pushed the updated branch to `website-call-indigo/codex/release-v0.9.0-publish-remote`.