### PR TITLE
[codex] standardize Strapi/EasyPanel scheduler contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable platform-level changes for this repository are documented here.
 
 - Patched `@bretwardjames/ghp-cli` so  displays repo workspace config correctly instead of reporting an empty workspace
 - Restored working `launch-apps` and `launch-apps-open` GHP shortcuts for the shared `launchops` project flow
+- Added the Easypanel/Strapi scheduler contract doc to standardize recurring backend work on the VPS side
 
 ## 0.0.1
 

--- a/docs/operations/easypanel-strapi-scheduler-contract.md
+++ b/docs/operations/easypanel-strapi-scheduler-contract.md
@@ -1,0 +1,37 @@
+# Easypanel Strapi Scheduler Contract
+
+## Purpose
+
+Scheduled backend work for this platform belongs on the Strapi / EasyPanel side, not on Vercel.
+
+This keeps the scheduler aligned with the system that owns the CMS state, deployment runtime, and production backend behavior.
+
+## Standard
+
+- Use Strapi built-in cron or a Strapi-owned scheduled job mechanism for recurring backend tasks.
+- Run the scheduler on the EasyPanel VPS that hosts Strapi.
+- Keep Vercel focused on frontend delivery and normal request handling.
+- Use webhooks or explicit admin-triggered actions when a task should run immediately after content changes.
+
+## Non-goals
+
+- Do not add Vercel cron jobs for Strapi maintenance or content workflows.
+- Do not duplicate the same scheduled task in both Vercel and Strapi.
+- Do not move backend ownership into the frontend repo.
+
+## Operational Flow
+
+1. Strapi performs or exposes the scheduled action.
+2. EasyPanel hosts the running Strapi process.
+3. The frontend consumes the resulting API state or receives webhook-driven updates.
+4. Health checks stay available as normal routes, but they are not scheduler triggers.
+
+## Validation
+
+- Confirm the scheduled job exists in the Strapi / EasyPanel deployment path.
+- Confirm `vercel.json` does not define cron entries for backend scheduling.
+- Confirm frontend deployments do not depend on Vercel scheduler behavior.
+
+## Reference
+
+- Repository changelog entry for the Vercel cron removal.


### PR DESCRIPTION
## What changed
- Adds a small operational doc that standardizes scheduled backend work on the Strapi / EasyPanel side.
- Documents that Vercel should stay out of recurring backend execution for this platform.
- Keeps the note tied into the existing `Unreleased` changelog entry.

## Why
- The repo already uses Strapi on EasyPanel as the production backend standard.
- This keeps the scheduler contract aligned with the upstream CMS/runtime owner and avoids duplicating responsibility in Vercel.

## Validation
- Confirmed the new doc is isolated in its own worktree and branch.
- Ran `git diff --check` before commit.
- Pushed the branch to `website-call-indigo/codex/easypanel-strapi-scheduler-contract`.