### PR TITLE
[codex] collapse Vercel regions to a Hobby-safe single region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable platform-level changes for this repository are documented here.
 - Patched `@bretwardjames/ghp-cli` so  displays repo workspace config correctly instead of reporting an empty workspace
 - Restored working `launch-apps` and `launch-apps-open` GHP shortcuts for the shared `launchops` project flow
 - Added the Easypanel/Strapi scheduler contract doc to standardize recurring backend work on the VPS side
+- Collapsed Vercel to a single region so the deployment config stays within Hobby plan limits
 
 ## 0.0.1
 

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
       "memory": 1024
     }
   },
-  "regions": ["iad1", "sfo1"],
+  "regions": ["iad1"],
   "headers": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## What changed
- Collapses `vercel.json` from two serverless regions to one region.
- Keeps the existing frontend deployment contract intact while staying within Vercel Hobby limits.
- Adds a matching changelog note under `Unreleased`.

## Why
- Vercel Hobby does not allow the multi-region serverless setup that was failing deployment validation.
- The repo standard here is to keep the smallest safe config change and preserve the existing production workflow.

## Validation
- Parsed `vercel.json` locally to confirm the config remains valid.
- Ran `git diff --check` before commit.
- Confirmed the branch was pushed to GitHub.